### PR TITLE
Gendustry Bee Modifier Logic Fix

### DIFF
--- a/src/main/scala/net/bdew/gendustry/custom/BeeMutation.scala
+++ b/src/main/scala/net/bdew/gendustry/custom/BeeMutation.scala
@@ -71,11 +71,11 @@ class BeeMutation(
       var processedChance = chance
       processedChance *= BeeModifiers
         .from(housing)
-        .getMutationModifier(genome0, genome1, processedChance)
+        .getMutationModifier(genome0, genome1, 1f)
       processedChance *= bkm.getBeeModifier.getMutationModifier(
         genome0,
         genome1,
-        processedChance
+        1f
       )
       processedChance
     }

--- a/src/main/scala/net/bdew/gendustry/forestry/BeeModifiers.scala
+++ b/src/main/scala/net/bdew/gendustry/forestry/BeeModifiers.scala
@@ -24,8 +24,8 @@ case class BeeModifiers(modifiers: Traversable[IBeeModifier])
       genome: IBeeGenome,
       currentModifier: Float
   ): Float =
-    modifiers.foldLeft(1f)((v, m) =>
-      m.getTerritoryModifier(genome, v * currentModifier)
+    modifiers.foldLeft(currentModifier)((v, m) =>
+      v * m.getTerritoryModifier(genome, v)
     )
 
   override def getMutationModifier(
@@ -33,8 +33,8 @@ case class BeeModifiers(modifiers: Traversable[IBeeModifier])
       mate: IBeeGenome,
       currentModifier: Float
   ): Float =
-    modifiers.foldLeft(1f)((v, m) =>
-      m.getMutationModifier(genome, mate, v * currentModifier)
+    modifiers.foldLeft(currentModifier)((v, m) =>
+      v * m.getMutationModifier(genome, mate, v)
     )
 
   override def getLifespanModifier(
@@ -42,32 +42,32 @@ case class BeeModifiers(modifiers: Traversable[IBeeModifier])
       mate: IBeeGenome,
       currentModifier: Float
   ): Float =
-    modifiers.foldLeft(1f)((v, m) =>
-      m.getLifespanModifier(genome, mate, v * currentModifier)
+    modifiers.foldLeft(currentModifier)((v, m) =>
+      v * m.getLifespanModifier(genome, mate, v)
     )
 
   override def getProductionModifier(
       genome: IBeeGenome,
       currentModifier: Float
   ): Float =
-    modifiers.foldLeft(1f)((v, m) =>
-      m.getProductionModifier(genome, v * currentModifier)
+    modifiers.foldLeft(currentModifier)((v, m) =>
+      v + m.getProductionModifier(genome, v)
     )
 
   override def getFloweringModifier(
       genome: IBeeGenome,
       currentModifier: Float
   ): Float =
-    modifiers.foldLeft(1f)((v, m) =>
-      m.getFloweringModifier(genome, v * currentModifier)
+    modifiers.foldLeft(currentModifier)((v, m) =>
+      v * m.getFloweringModifier(genome, v)
     )
 
   override def getGeneticDecay(
       genome: IBeeGenome,
       currentModifier: Float
   ): Float =
-    modifiers.foldLeft(1f)((v, m) =>
-      m.getGeneticDecay(genome, v * currentModifier)
+    modifiers.foldLeft(currentModifier)((v, m) =>
+      v * m.getGeneticDecay(genome, v)
     )
 
   override def isSealed: Boolean = modifiers.exists(_.isSealed)


### PR DESCRIPTION
Issue:https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15357

Problem: The bee modifier is incorrectly calculated for gendustry bee species(red, blue, yellow bee etc). And behaves different from the ones made using forestry/extrabees api. 

Cause: getXXXModifier methods for net.bdew.gendustry.forestry.BeeModifiers class and forestry.apiculture.BeeHousingModifier class have different implementations.

Solution: change the implementation so that it keeps logical consistency with the forestry ones.


The solution was tested by breeding Common Princess and Diligent Drone to get Red bees. Breeding was done in an alveary with 2 stimulator having 4 golden electron tubes each which in theory guaranties success in mutation to Red bee species(10% base chance * 0.75 HARD bee keeping mode multiplier * 25 from stimulators = 192% final mutation chance)

Before change: mutation isn't guaranteed. And multiple breeding attempts converged the observed mutation chance to ~7.5%
After change: mutation is guaranteed and works 100% of the time

