### PR TITLE
Added oreDict entries for colored combs

### DIFF
--- a/src/main/resources/assets/gendustry/config/bees_color.cfg
+++ b/src/main/resources/assets/gendustry/config/bees_color.cfg
@@ -387,6 +387,25 @@ if HaveForestryModule Bees <<
 
     }
 
+    recipes { // === OreDict entries for honeycombs
+        regOreDict: S:gendustry:"HoneyComb.black"     => beeComb
+        regOreDict: S:gendustry:"HoneyComb.red"       => beeComb
+        regOreDict: S:gendustry:"HoneyComb.green"     => beeComb
+        regOreDict: S:gendustry:"HoneyComb.brown"     => beeComb
+        regOreDict: S:gendustry:"HoneyComb.blue"      => beeComb
+        regOreDict: S:gendustry:"HoneyComb.purple"    => beeComb
+        regOreDict: S:gendustry:"HoneyComb.cyan"      => beeComb
+        regOreDict: S:gendustry:"HoneyComb.silver"    => beeComb
+        regOreDict: S:gendustry:"HoneyComb.gray"      => beeComb
+        regOreDict: S:gendustry:"HoneyComb.pink"      => beeComb
+        regOreDict: S:gendustry:"HoneyComb.lime"      => beeComb
+        regOreDict: S:gendustry:"HoneyComb.yellow"    => beeComb
+        regOreDict: S:gendustry:"HoneyComb.lightblue" => beeComb
+        regOreDict: S:gendustry:"HoneyComb.magenta"   => beeComb
+        regOreDict: S:gendustry:"HoneyComb.orange"    => beeComb
+        regOreDict: S:gendustry:"HoneyComb.white"     => beeComb
+    }
+
     // Describes Custom Honeydrops. Same format as combs.
     cfg HoneyDrops {
         cfg black   	{ ID = 10	PrimaryColor = 0xE8D56A		SecondaryColor = 0x1E1B1B }


### PR DESCRIPTION
Fixes GTNewHorizons/GT-New-Horizons-Modpack/issues/16913

Adds the "beeComb" oreDict tag to colored Genedustry combs. This allows them to be used in comb recipes, and lets them to be filtered by the ME Storage Bus.