### PR TITLE
Fix Pollen Collection Kit NPE

### DIFF
--- a/src/main/scala/net/bdew/gendustry/items/PollenKit.scala
+++ b/src/main/scala/net/bdew/gendustry/items/PollenKit.scala
@@ -11,6 +11,7 @@ package net.bdew.gendustry.items
 
 import forestry.api.arboriculture.{EnumGermlingType, ITreeRoot}
 import forestry.api.genetics.IPollinatable
+import forestry.arboriculture.tiles.TileLeaves
 import net.bdew.gendustry.forestry.GeneticsHelper
 import net.bdew.lib.block.BlockRef
 import net.bdew.lib.items.{ItemUtils, SimpleItem}
@@ -35,7 +36,13 @@ object PollenKit extends SimpleItem("PollenKit") {
     if (!world.isRemote) {
       if (player.inventory.getCurrentItem.getItem != this) return false
       val blockRef = BlockRef(x, y, z)
-      (blockRef.getTile[IPollinatable](world) map { te => te.getPollen }
+      (blockRef.getTile[IPollinatable](world) flatMap { te =>
+        te match {
+          case leaf: TileLeaves =>
+            Some(leaf.getTree)
+          case _ => None
+        }
+      }
       // If block is not IPollinatable, check for vanilla leafs conversion
         orElse (blockRef.block(world) flatMap { bl =>
           GeneticsHelper.getErsatzPollen(bl, blockRef.meta(world))


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17877
Fixes an NPE that occurred when using a Pollen Collection Kit on player-placed forestry leaves.

`getPollen` returns null if the leaf was placed by the player, otherwise it returns the result of `getTree`.
This fix calls `getTree` directly and makes Pollen Collection Kit possible to collect pollens from player-placed leaves.
Originally, it can be used on player-placed **vanilla leaves**, so I don't think this fix will affect the balance.