### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/gendustry/lang/en_US.lang
+++ b/src/main/resources/assets/gendustry/lang/en_US.lang
@@ -55,6 +55,7 @@ item.gendustry.protein.can.name=Protein Can
 
 # ==== UPGRADES ====
 
+item.gendustry.apiary.upgrade.name=Upgrade
 gendustry.upgrades.prod.name=Production Upgrade
 gendustry.upgrades.life.name=Lifespan Upgrade
 gendustry.upgrades.flowering.name=Flowering Upgrade
@@ -237,6 +238,7 @@ gendustry.bees.species.derpious.description=A curious specimen, seems to be most
 
 # ==== COMBS ====
 
+item.gendustry.HoneyComb.name=Colored Comb
 gendustry.honeycomb.black.name=Black Colored Comb
 gendustry.honeycomb.red.name=Red Colored Comb
 gendustry.honeycomb.green.name=Green Colored Comb
@@ -254,6 +256,7 @@ gendustry.honeycomb.magenta.name=Magenta Colored Comb
 gendustry.honeycomb.orange.name=Orange Colored Comb
 gendustry.honeycomb.white.name=White Colored Comb
 
+item.gendustry.HoneyDrop.name=Colored Honey Drop
 gendustry.honeydrop.black.name=Black Colored Honey Drop
 gendustry.honeydrop.red.name=Red Colored Honey Drop
 gendustry.honeydrop.green.name=Green Colored Honey Drop


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.