### PR TITLE
Speed up pack boot a little more

### DIFF
--- a/src/main/scala/net/bdew/gendustry/custom/BeeSpecies.scala
+++ b/src/main/scala/net/bdew/gendustry/custom/BeeSpecies.scala
@@ -31,7 +31,7 @@ import scala.collection.mutable
 
 class BeeSpecies(cfg: ConfigSection, ident: String) extends IAlleleBeeSpecies {
   // IAllele
-  override val getName = Misc.toLocal("gendustry.bees.species." + ident)
+  override def getName = Misc.toLocal("gendustry.bees.species." + ident)
   override val isDominant = cfg.getBoolean("Dominant")
   override val getUID = "gendustry.bee." + ident
 
@@ -61,7 +61,7 @@ class BeeSpecies(cfg: ConfigSection, ident: String) extends IAlleleBeeSpecies {
   )
   override val getAuthority = cfg.getString("Authority")
   override val getBinomial = cfg.getString("Binominal")
-  override val getDescription =
+  override def getDescription =
     if (Misc.hasLocal("gendustry.bees.species." + ident + ".description"))
       Misc.toLocal("gendustry.bees.species." + ident + ".description")
     else ""

--- a/src/main/scala/net/bdew/gendustry/forestry/GeneRecipe.scala
+++ b/src/main/scala/net/bdew/gendustry/forestry/GeneRecipe.scala
@@ -20,20 +20,33 @@ class GeneRecipe extends IRecipe {
     getCraftingResult(inv) != null
   def getCraftingResult(inv: InventoryCrafting): ItemStack = {
     var template: ItemStack = null
-    var samples = Seq.empty[GeneSampleInfo]
-    for (i <- 0 until 3; j <- 0 until 3) {
-      val itm = inv.getStackInRowAndColumn(i, j)
-      if (itm != null && itm.getItem == GeneSample && itm.hasTagCompound)
-        samples :+= GeneSample.getInfo(itm)
-      else if (itm != null && itm.getItem == GeneTemplate && template == null)
-        template = itm
-      else if (itm != null)
-        return null
+    var samples: Array[GeneSampleInfo] = null
+    var sampleCount = 0
+    var i = 0
+    while (i < 3) {
+      var j = 0
+      while (j < 3) {
+        val itm = inv.getStackInRowAndColumn(i, j)
+        if (itm != null && itm.getItem == GeneSample && itm.hasTagCompound) {
+          val sample = GeneSample.getInfo(itm)
+          if (sample.root == null || sample.allele == null) return null
+          if (samples == null) samples = new Array[GeneSampleInfo](9)
+          samples(sampleCount) = sample
+          sampleCount += 1
+        } else if (
+          itm != null && itm.getItem == GeneTemplate && template == null
+        ) template = itm
+        else if (itm != null) return null
+        j += 1
+      }
+      i += 1
     }
-    if (samples.isEmpty || template == null) return null
+    if (sampleCount == 0 || template == null) return null
     val out = template.copy()
-    for (s <- samples) {
-      if (!GeneTemplate.addSample(out, s)) return null
+    i = 0
+    while (i < sampleCount) {
+      if (!GeneTemplate.addSample(out, samples(i))) return null
+      i += 1
     }
     return out
   }

--- a/src/main/scala/net/bdew/gendustry/misc/ResourceListener.scala
+++ b/src/main/scala/net/bdew/gendustry/misc/ResourceListener.scala
@@ -24,11 +24,15 @@ import net.minecraft.client.resources.{
 }
 
 object ResourceListener extends IResourceManagerReloadListener {
+  private var registering = false
+
   def init() {
     Gendustry.logInfo("Registered reload listener")
-    Client.minecraft.getResourceManager
+    val resourceManager = Client.minecraft.getResourceManager
       .asInstanceOf[IReloadableResourceManager]
-      .registerReloadListener(this)
+    registering = true
+    try resourceManager.registerReloadListener(this)
+    finally registering = false
   }
 
   def loadLangFile(lang: String, fileName: String) {
@@ -44,6 +48,7 @@ object ResourceListener extends IResourceManagerReloadListener {
   }
 
   override def onResourceManagerReload(rm: IResourceManager) {
+    if (registering) return
     val newLang = FMLClientHandler.instance().getCurrentLanguage
     Gendustry.logInfo("Resource manager reload, new language: %s", newLang)
     val configFiles = Gendustry.configDir.list().sorted


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
This PR does two things:
- Skip language reload during the registration listener, relying on the global reload later
- Optimize the gene recipe matcher because it's slowing down Blood Magic's and GT5's crafting recipe scans

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
